### PR TITLE
SPIR-V: enable nested if conditions

### DIFF
--- a/include/nuanceur/generators/SpirvShaderGenerator.h
+++ b/include/nuanceur/generators/SpirvShaderGenerator.h
@@ -2,6 +2,7 @@
 
 #include <set>
 #include <map>
+#include <stack>
 #include <cstring>
 #include "nuanceur/builder/ShaderBuilder.h"
 #include "Stream.h"
@@ -257,6 +258,6 @@ namespace Nuanceur
 		std::map<int32, uint32> m_intConstantIds;
 		std::map<uint32, uint32> m_uintConstantIds;
 		uint32 m_nextId = EMPTY_ID + 1;
-		uint32 m_endLabelId = 0;
+		std::stack<uint32> m_endLabelIds;
 	};
 }

--- a/src/generators/SpirvShaderGenerator.cpp
+++ b/src/generators/SpirvShaderGenerator.cpp
@@ -769,25 +769,25 @@ void CSpirvShaderGenerator::Generate()
 				break;
 			case CShaderBuilder::STATEMENT_OP_IF_BEGIN:
 				{
-					assert(m_endLabelId == 0);
 					auto src1Id = LoadFromSymbol(src1Ref);
 					auto beginLabelId = AllocateId();
 					auto endLabelId = AllocateId();
 					WriteOp(spv::OpSelectionMerge, endLabelId, spv::SelectionControlMaskNone);
 					WriteOp(spv::OpBranchConditional, src1Id, beginLabelId, endLabelId);
 					WriteOp(spv::OpLabel, beginLabelId);
-					m_endLabelId = endLabelId;
+					m_endLabelIds.push(endLabelId);
 				}
 				break;
 			case CShaderBuilder::STATEMENT_OP_IF_END:
 				{
-					assert(m_endLabelId != 0);
+					assert(m_endLabelIds.size() > 0);
+					auto endLabelId = m_endLabelIds.top();
 					if(!returnInBlock)
 					{
-						WriteOp(spv::OpBranch, m_endLabelId);
+						WriteOp(spv::OpBranch, endLabelId);
 					}
-					WriteOp(spv::OpLabel, m_endLabelId);
-					m_endLabelId = 0;
+					WriteOp(spv::OpLabel, endLabelId);
+					m_endLabelIds.pop();
 					returnInBlock = false;
 				}
 				break;


### PR DESCRIPTION
was there a reason nested if werent supported?

currenly we can't do 16bit unaligned write without nested if, or atomic operation, but we do have few choice
1) as below check for aligment and do 2x8 bit writes
2) dont check, but instead always do 2x8 bit writes
3) change the [stride](https://github.com/jpd002/Nuanceur/blob/master/src/generators/SpirvShaderGenerator.cpp#L267) and traverse in 8 bit
4) use 8 bit buffer with 16 bit write


```cpp
void CMemoryUtils::Memory_Write16(Nuanceur::CShaderBuilder& b, Nuanceur::CArrayUcharValue memoryBuffer8, Nuanceur::CArrayUshortValue memoryBuffer16, Nuanceur::CIntValue address, Nuanceur::CUintValue value)
{
	#if 1
	auto is16BitAligned = (ToUint(address) & NewUint(b, 2)) != NewUint(b, 0);
	BeginIf(b, !is16BitAligned);
	{
		Store(memoryBuffer16, address / NewInt(b, 2), ToUshort(value));
	}
	EndIf(b);
	BeginIf(b, is16BitAligned);
	{
		Store(memoryBuffer8, address + NewInt(b, 0), ToUchar(value));
		Store(memoryBuffer8, address + NewInt(b, 1), ToUchar(value >> NewUint(b, 8)));
	}
	EndIf(b);
	#elif 0
		Store(memoryBuffer8, address + NewInt(b, 0), ToUchar(value));
		Store(memoryBuffer8, address + NewInt(b, 1), ToUchar(value >> NewUint(b, 8)));
	#elif 0
		Store(memoryBuffer16, address, ToUshort(value));
	#else
		Store(memoryBuffer8, address, ToUshort(value));
	#endif
```